### PR TITLE
Add option to specify letters’ text attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Call the following methods on any `UIImageView` instance to set the image:
 + `- (void)setImageWithString:(NSString *)string color:(UIColor *)color`
 + `- (void)setImageWithString:(NSString *)string color:(UIColor *)color circular:(BOOL)isCircular`
 + `- (void)setImageWithString:(NSString *)string color:(UIColor *)color circular:(BOOL)isCircular fontName:(NSString *)fontName`
++ `- (void)setImageWithString:(NSString *)string color:(UIColor *)color circular:(BOOL)isCircular textAttributes:(NSDictionary *)textAttributes`
 
 `string` is the string used to generate the initials. This should be a user's full name if available.
 
@@ -42,6 +43,8 @@ Call the following methods on any `UIImageView` instance to set the image:
 `isCircular` is a boolean parameter that will automatically clip the image to a circle if enabled.
 
 `fontName` is a string that specifies a custom font. Pass in `nil` to use the system font by default. The list of provided font identifiers can be found [here](http://iosfonts.com). 
+
+`textAttributes` is an NSDictionary that allows you to specify font, text color, shadow properties, etc., for the letters text, using the keys found in `NSAttributedString.h`.
 
 ##### Example
 

--- a/UIImageView+Letters/UIImageView+Letters.h
+++ b/UIImageView+Letters/UIImageView+Letters.h
@@ -64,4 +64,14 @@
  */
 - (void)setImageWithString:(NSString *)string color:(UIColor *)color circular:(BOOL)isCircular fontName:(NSString *)fontName;
 
+/**
+ Sets the image property of the view based on initial text, a specified background color, custom text attributes, and a circular clipping
+
+ @param string The string used to generate the initials. This should be a user's full name if available
+ @param color (optional) This optional paramter sets the background of the image. If not provided, a random color will be generated
+ @param isCircular This boolean will determine if the image view will be clipped to a circular shape
+ @param textAttributes This dictionary allows you to specify font, text color, shadow properties, etc., for the letters text, using the keys found in NSAttributedString.h
+ */
+- (void)setImageWithString:(NSString *)string color:(UIColor *)color circular:(BOOL)isCircular textAttributes:(NSDictionary *)textAttributes;
+
 @end

--- a/UIImageView+Letters/UIImageView+Letters.m
+++ b/UIImageView+Letters/UIImageView+Letters.m
@@ -48,6 +48,10 @@ static const CGFloat kFontResizingProportion = 0.48f;
 }
 
 - (void)setImageWithString:(NSString *)string color:(UIColor *)color circular:(BOOL)isCircular fontName: (NSString *)fontName {
+    [self setImageWithString:string color:color circular:isCircular textAttributes:[self defaultTextAttributesForFontName:fontName]];
+}
+
+- (void)setImageWithString:(NSString *)string color:(UIColor *)color circular:(BOOL)isCircular textAttributes:(NSDictionary *)textAttributes {
     NSMutableString *displayString = [NSMutableString stringWithString:@""];
     
     NSMutableArray *words = [[string componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] mutableCopy];
@@ -80,8 +84,8 @@ static const CGFloat kFontResizingProportion = 0.48f;
     }
     
     UIColor *backgroundColor = color ? color : [self randomColor];
-    
-    self.image = [self imageSnapshotFromText:[displayString uppercaseString] backgroundColor:backgroundColor circular:isCircular fontName:fontName];
+
+    self.image = [self imageSnapshotFromText:[displayString uppercaseString] backgroundColor:backgroundColor circular:isCircular textAttributes:textAttributes];
 }
 
 #pragma mark - Helpers
@@ -118,7 +122,14 @@ static const CGFloat kFontResizingProportion = 0.48f;
     return [UIColor colorWithRed:red green:green blue:blue alpha:1.0f];
 }
 
-- (UIImage *)imageSnapshotFromText:(NSString *)text backgroundColor:(UIColor *)color circular:(BOOL)isCircular fontName:(NSString *)fontName {
+- (NSDictionary *)defaultTextAttributesForFontName:(NSString *)fontName {
+    return @{
+        NSFontAttributeName:[self fontForText:fontName],
+        NSForegroundColorAttributeName:[UIColor whiteColor]
+    };
+}
+
+- (UIImage *)imageSnapshotFromText:(NSString *)text backgroundColor:(UIColor *)color circular:(BOOL)isCircular textAttributes:(NSDictionary *)textAttributes {
     
     CGFloat scale = [UIScreen mainScreen].scale;
     
@@ -155,10 +166,6 @@ static const CGFloat kFontResizingProportion = 0.48f;
     //
     // Draw text in the context
     //
-    NSDictionary *textAttributes = @{
-        NSFontAttributeName:[self fontForText:fontName],
-        NSForegroundColorAttributeName:[UIColor whiteColor]
-    };
     CGSize textSize = [text sizeWithAttributes:textAttributes];
     CGRect bounds = self.bounds;
     

--- a/UIImageView+Letters/UIImageView+Letters.m
+++ b/UIImageView+Letters/UIImageView+Letters.m
@@ -155,17 +155,18 @@ static const CGFloat kFontResizingProportion = 0.48f;
     //
     // Draw text in the context
     //
-    CGSize textSize = [text sizeWithAttributes:@{NSFontAttributeName:[self fontForText:fontName]}];
+    NSDictionary *textAttributes = @{
+        NSFontAttributeName:[self fontForText:fontName],
+        NSForegroundColorAttributeName:[UIColor whiteColor]
+    };
+    CGSize textSize = [text sizeWithAttributes:textAttributes];
     CGRect bounds = self.bounds;
     
     [text drawInRect:CGRectMake(bounds.size.width/2 - textSize.width/2,
                                 bounds.size.height/2 - textSize.height/2,
                                 textSize.width,
                                 textSize.height)
-      withAttributes:@{
-                       NSFontAttributeName:[self fontForText:fontName],
-                       NSForegroundColorAttributeName:[UIColor whiteColor]
-                       }];
+      withAttributes:textAttributes];
     
     UIImage *snapshot = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();


### PR DESCRIPTION
This adds the ability for a user to specify arbitrary `NSAttributedString` attributes to use in the letters text.

### Why

My primary interest was to set the text color of the letters, but `NSAttributedString` attributes add a whole plethora of options.

### Example

```objc
[imageView setImageWithString:@"John Smith" color:[UIColor redColor] circular:YES textAttributes:@{
    NSFontAttributeName: [UIFont fontWithName:@"Futura-Medium" size:44.0],
    NSForegroundColorAttributeName: [UIColor yellowColor],
}];
```

### How to test

In the absence of formal unit tests, build and run the sample project and ensure nothing looks broken.